### PR TITLE
fix: 修复旧版配置未迁移导致升级后广告屏蔽等开关失效

### DIFF
--- a/app/src/main/java/com/forbidad4tieba/hook/config/ConfigManager.kt
+++ b/app/src/main/java/com/forbidad4tieba/hook/config/ConfigManager.kt
@@ -218,6 +218,38 @@ object ConfigManager {
 
     @Volatile private var restrictedFeatureUnlockBlockedByRemote: Boolean = false
     @Volatile private var environmentWarningDialogActive: Boolean = false
+    private val legacyMigrationSkipPrefixes = listOf(
+        "hook_symbol_",
+        "last_sign_date_",
+        "last_success_day_",
+        "about_",
+    )
+    private val legacyCustomPostFilterChildKeys = listOf(
+        KEY_FILTER_POST_VOTE,
+        KEY_FILTER_POST_VIDEO,
+        KEY_FILTER_POST_REPLY,
+        KEY_FILTER_POST_HOT,
+        KEY_FILTER_POST_GOODS,
+        KEY_FILTER_POST_GAME_BOOKING,
+        KEY_FILTER_POST_HELP,
+        KEY_FILTER_POST_SCORE,
+        KEY_FILTER_POST_LOTTERY,
+        KEY_FILTER_POST_LIVE,
+        KEY_FILTER_POST_RECOMMEND_FORUM,
+        KEY_FILTER_POST_UNFOLLOWED_FORUM,
+        KEY_FILTER_POST_FORUM_KEYWORD,
+        KEY_FILTER_POST_MODEL_SCORE,
+    )
+    private val legacyAdBlockChildKeys = listOf(
+        KEY_BLOCK_AD_FEED,
+        KEY_BLOCK_AD_POST_PAGE,
+        KEY_BLOCK_AD_FORUM_PAGE,
+        KEY_BLOCK_AD_STRATEGY,
+        KEY_BLOCK_AD_SEARCH_BOX_TEXT,
+        KEY_BLOCK_AD_HOME_TOP_BAR,
+        KEY_BLOCK_AD_MINE_TAB_WEB,
+        KEY_BLOCK_AD_HOME_SIDE_BAR_WEB,
+    )
 
     const val HOME_TOP_TAB_SOURCE_HOST = "host"
     const val HOME_TOP_TAB_SOURCE_MODULE = "module"
@@ -429,9 +461,11 @@ object ConfigManager {
             if (prefs != null) return
             val appCtx = context.applicationContext ?: context
             val localPrefs = appCtx.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+            val localLegacyPrefs = appCtx.getSharedPreferences(LEGACY_MIXED_PREFS_NAME, Context.MODE_PRIVATE)
             appContext = appCtx
             prefs = localPrefs
             ensureUserSettingsVersion(localPrefs)
+            seedLegacyCompatPrefsIfNeeded(localPrefs, localLegacyPrefs)
 
             restrictedFeatureUnlockBlockedByRemote = getModuleStatePrefs(appCtx)
                 .getBoolean(KEY_REMOTE_RESTRICTED_FEATURES_LOCK_ACTIVE, false)
@@ -512,6 +546,124 @@ object ConfigManager {
             p.edit()
                 .putInt(KEY_USER_SETTINGS_VERSION_CODE, currentVersion)
                 .apply()
+        }
+    }
+
+    /**
+     * 为旧版混合配置补种新版主开关，避免升级后因缺少父级开关导致广告屏蔽/帖子过滤整体失效。
+     *
+     * 输入为当前新版用户配置和旧版混合配置；输出为无返回值。
+     * 边界条件：仅在当前键缺失时写入，不覆盖用户在新版里已经手动保存过的值；如果旧版配置为空或不是旧 schema，则直接跳过。
+     */
+    private fun seedLegacyCompatPrefsIfNeeded(
+        currentPrefs: SharedPreferences,
+        legacyPrefs: SharedPreferences,
+    ) {
+        if (!shouldSeedLegacyMasterToggles(legacyPrefs)) return
+
+        val changedKeys = ArrayList<String>(12)
+        val editor = currentPrefs.edit()
+
+        fun putBooleanIfMissing(key: String, value: Boolean) {
+            if (currentPrefs.contains(key)) return
+            editor.putBoolean(key, value)
+            changedKeys.add(key)
+        }
+
+        copyLegacyEntriesIfMissing(
+            currentPrefs = currentPrefs,
+            legacyPrefs = legacyPrefs,
+            editor = editor,
+            changedKeys = changedKeys,
+        )
+
+        if (!currentPrefs.contains(KEY_RESTRICTED_FEATURES_UNLOCKED)) {
+            putBooleanIfMissing(KEY_RESTRICTED_FEATURES_UNLOCKED, true)
+        }
+
+        if (!currentPrefs.contains(KEY_ENABLE_CUSTOM_POST_FILTER) && shouldEnableLegacyCustomPostFilter(legacyPrefs)) {
+            putBooleanIfMissing(KEY_ENABLE_CUSTOM_POST_FILTER, true)
+        }
+
+        if (!currentPrefs.contains(KEY_BLOCK_AD)) {
+            putBooleanIfMissing(KEY_BLOCK_AD, true)
+            legacyAdBlockChildKeys.forEach { key ->
+                putBooleanIfMissing(key, legacyPrefs.getBoolean(key, true))
+            }
+        }
+
+        if (changedKeys.isEmpty()) return
+        editor.apply()
+    }
+
+    /**
+     * 将旧版混合配置里与用户偏好直接相关的缺失键补种到新版配置中。
+     *
+     * 输入为当前配置、旧版配置、待提交 editor 和变更键列表；输出为无返回值。
+     * 边界条件：只迁移当前缺失的键，且会跳过符号缓存、统计时间戳等内部字段，避免把历史缓存误写入新版用户配置。
+     */
+    private fun copyLegacyEntriesIfMissing(
+        currentPrefs: SharedPreferences,
+        legacyPrefs: SharedPreferences,
+        editor: SharedPreferences.Editor,
+        changedKeys: MutableList<String>,
+    ) {
+        for ((key, value) in legacyPrefs.all) {
+            if (shouldSkipLegacyMigrationKey(key) || currentPrefs.contains(key)) continue
+            when (value) {
+                is Boolean -> editor.putBoolean(key, value)
+                is Int -> editor.putInt(key, value)
+                is Long -> editor.putLong(key, value)
+                is Float -> editor.putFloat(key, value)
+                is String -> editor.putString(key, value)
+                is Set<*> -> {
+                    val strings = value.filterIsInstance<String>().toSet()
+                    if (strings.size != value.size) continue
+                    editor.putStringSet(key, strings)
+                }
+                else -> continue
+            }
+            changedKeys.add(key)
+        }
+    }
+
+    /**
+     * 判断旧版混合配置是否属于需要补种新版主开关的历史 schema。
+     *
+     * 输入为旧版混合配置；输出为是否需要执行兼容补种。
+     * 边界条件：旧配置为空、版本号缺失或已经达到当前最低兼容版本时返回 false，避免影响新安装或已完成迁移的用户。
+     */
+    private fun shouldSeedLegacyMasterToggles(legacyPrefs: SharedPreferences): Boolean {
+        if (legacyPrefs.all.isEmpty()) return false
+        val legacyVersion = legacyPrefs.getInt(KEY_USER_SETTINGS_VERSION_CODE, 0)
+        val minSupportedVersion = BuildConfig.MIN_SUPPORTED_USER_SETTINGS_VERSION_CODE
+            .coerceAtMost(BuildConfig.VERSION_CODE)
+        return legacyVersion in 1 until minSupportedVersion
+    }
+
+    /**
+     * 判断某个旧版键是否应跳过自动迁移。
+     *
+     * 输入为旧版配置键名；输出为是否跳过。
+     * 边界条件：版本号、符号缓存、时间戳类运行态数据和 about 缓存均不迁移，避免污染新版用户偏好文件。
+     */
+    private fun shouldSkipLegacyMigrationKey(key: String): Boolean {
+        if (key == KEY_USER_SETTINGS_VERSION_CODE) return true
+        return legacyMigrationSkipPrefixes.any { key.startsWith(it) }
+    }
+
+    /**
+     * 判断旧版配置是否启用了自定义帖子过滤主开关，或至少存在生效中的子项配置。
+     *
+     * 输入为旧版混合配置；输出为是否应在新版配置里补种 `enable_custom_post_filter=true`。
+     * 边界条件：如果旧版显式关闭主开关则返回 false；若旧版没有主开关，则以任一子项为 true 作为兼容启用信号。
+     */
+    private fun shouldEnableLegacyCustomPostFilter(legacyPrefs: SharedPreferences): Boolean {
+        if (legacyPrefs.contains(KEY_ENABLE_CUSTOM_POST_FILTER)) {
+            return legacyPrefs.getBoolean(KEY_ENABLE_CUSTOM_POST_FILTER, false)
+        }
+        return legacyCustomPostFilterChildKeys.any { key ->
+            legacyPrefs.getBoolean(key, false)
         }
     }
 

--- a/app/src/test/java/com/forbidad4tieba/hook/config/ConfigManagerTest.kt
+++ b/app/src/test/java/com/forbidad4tieba/hook/config/ConfigManagerTest.kt
@@ -238,6 +238,75 @@ class ConfigManagerTest {
     }
 
     @Test
+    fun legacyCompatSeedTurnsOnAdBlockMasterForLegacySchemaUsers() {
+        val current = mutableSharedPreferences(
+            mapOf("user_settings_version_code" to 32),
+        )
+        val legacy = mutableSharedPreferences(
+            mapOf("user_settings_version_code" to 17),
+        )
+
+        invokeLegacyCompatSeed(current, legacy)
+
+        assertTrue(current.getBoolean(ConfigManager.KEY_RESTRICTED_FEATURES_UNLOCKED, false))
+        assertTrue(current.getBoolean(ConfigManager.KEY_BLOCK_AD, false))
+        assertTrue(current.getBoolean(ConfigManager.KEY_BLOCK_AD_POST_PAGE, false))
+    }
+
+    @Test
+    fun legacyCompatSeedBackfillsCustomPostFilterParentFromLegacyChildren() {
+        val current = mutableSharedPreferences(
+            mapOf("user_settings_version_code" to 32),
+        )
+        val legacy = mutableSharedPreferences(
+            mapOf(
+                "user_settings_version_code" to 17,
+                ConfigManager.KEY_FILTER_POST_VIDEO to true,
+            ),
+        )
+
+        invokeLegacyCompatSeed(current, legacy)
+
+        assertTrue(current.getBoolean(ConfigManager.KEY_ENABLE_CUSTOM_POST_FILTER, false))
+    }
+
+    @Test
+    fun legacyCompatSeedCopiesMissingUserSettingsFromLegacyPrefs() {
+        val current = mutableSharedPreferences(
+            mapOf("user_settings_version_code" to 32),
+        )
+        val legacy = mutableSharedPreferences(
+            mapOf(
+                "user_settings_version_code" to 17,
+                ConfigManager.KEY_ENABLE_AUTO_LOAD_MORE to true,
+                ConfigManager.KEY_FILTER_ENTER_FORUM_WEB to true,
+            ),
+        )
+
+        invokeLegacyCompatSeed(current, legacy)
+
+        assertTrue(current.getBoolean(ConfigManager.KEY_ENABLE_AUTO_LOAD_MORE, false))
+        assertTrue(current.getBoolean(ConfigManager.KEY_FILTER_ENTER_FORUM_WEB, false))
+    }
+
+    @Test
+    fun legacyCompatSeedSkipsInternalHookSymbolCacheKeys() {
+        val current = mutableSharedPreferences(
+            mapOf("user_settings_version_code" to 32),
+        )
+        val legacy = mutableSharedPreferences(
+            mapOf(
+                "user_settings_version_code" to 17,
+                "hook_symbol_json_v19" to "{json}",
+            ),
+        )
+
+        invokeLegacyCompatSeed(current, legacy)
+
+        assertFalse(current.contains("hook_symbol_json_v19"))
+    }
+
+    @Test
     fun topAndBottomTabChildrenDoNotBecomeRuntimeActiveWhenParentIsOff() {
         withScanAvailability(
             mapOf(
@@ -549,6 +618,25 @@ class ConfigManagerTest {
         }
     }
 
+    /**
+     * 反射调用旧配置兼容补种逻辑，验证升级场景下的主开关迁移结果。
+     *
+     * 输入为当前配置和旧版混合配置；输出为无返回值。
+     * 边界条件：测试只覆盖缺失键补种，不依赖 Android 真正的磁盘 SharedPreferences 实现。
+     */
+    private fun invokeLegacyCompatSeed(
+        current: SharedPreferences,
+        legacy: SharedPreferences,
+    ) {
+        val method = ConfigManager::class.java.getDeclaredMethod(
+            "seedLegacyCompatPrefsIfNeeded",
+            SharedPreferences::class.java,
+            SharedPreferences::class.java,
+        )
+        method.isAccessible = true
+        method.invoke(ConfigManager, current, legacy)
+    }
+
     private fun sharedPreferences(values: Map<String, Any?>): SharedPreferences {
         return Proxy.newProxyInstance(
             SharedPreferences::class.java.classLoader,
@@ -565,6 +653,66 @@ class ConfigManagerTest {
                 "unregisterOnSharedPreferenceChangeListener",
                 -> Unit
                 "edit" -> error("edit() is not supported by test SharedPreferences")
+                else -> error("Unexpected SharedPreferences call: ${method.name}")
+            }
+        } as SharedPreferences
+    }
+
+    /**
+     * 构造一个可写的内存 SharedPreferences，用于测试迁移/补种这类会调用 `edit()` 的逻辑。
+     *
+     * 输入为初始键值；输出为可读写的 SharedPreferences 代理对象。
+     * 边界条件：仅实现当前测试需要的读写能力，未覆盖的方法会直接抛错，避免静默掩盖测试缺口。
+     */
+    private fun mutableSharedPreferences(values: Map<String, Any?>): SharedPreferences {
+        val store = LinkedHashMap(values)
+        return Proxy.newProxyInstance(
+            SharedPreferences::class.java.classLoader,
+            arrayOf(SharedPreferences::class.java),
+        ) { _, method, args ->
+            val key = args?.firstOrNull() as? String
+            when (method.name) {
+                "getBoolean" -> store[key] as? Boolean ?: args?.getOrNull(1) as Boolean
+                "getInt" -> store[key] as? Int ?: args?.getOrNull(1) as Int
+                "getString" -> store[key] as? String ?: args?.getOrNull(1) as? String
+                "contains" -> store.containsKey(key)
+                "getAll" -> LinkedHashMap(store)
+                "registerOnSharedPreferenceChangeListener",
+                "unregisterOnSharedPreferenceChangeListener",
+                -> Unit
+                "edit" -> {
+                    Proxy.newProxyInstance(
+                        SharedPreferences.Editor::class.java.classLoader,
+                        arrayOf(SharedPreferences.Editor::class.java),
+                    ) { _, editorMethod, editorArgs ->
+                        val editorKey = editorArgs?.firstOrNull() as? String
+                        when (editorMethod.name) {
+                            "putBoolean" -> {
+                                store[editorKey!!] = editorArgs[1] as Boolean
+                                null
+                            }
+                            "putInt" -> {
+                                store[editorKey!!] = editorArgs[1] as Int
+                                null
+                            }
+                            "putString" -> {
+                                store[editorKey!!] = editorArgs[1] as String?
+                                null
+                            }
+                            "remove" -> {
+                                store.remove(editorKey)
+                                null
+                            }
+                            "clear" -> {
+                                store.clear()
+                                null
+                            }
+                            "apply" -> null
+                            "commit" -> true
+                            else -> error("Unexpected SharedPreferences.Editor call: ${editorMethod.name}")
+                        }
+                    }
+                }
                 else -> error("Unexpected SharedPreferences call: ${method.name}")
             }
         } as SharedPreferences


### PR DESCRIPTION
## 问题
- 从旧版覆盖升级到新版后，模块开始读取 `tbhook_user_settings`，但旧版 `tiebahook_settings` 中的关键用户配置没有迁移过来。
- 运行时会导致 `block_ad`、`block_ad_post_page`、`restricted_features_unlocked` 等主开关缺失。
- 进一步表现为帖子页广告屏蔽等功能在升级后失效。

## 修复
- 在 `ConfigManager.init()` 中补充旧版混合配置到新版用户配置的兼容迁移。
- 仅补种当前缺失的键，不覆盖新版已保存的值。
- 跳过 `hook_symbol_*`、签到时间戳、about 缓存等内部运行态字段。
- 当旧版没有显式主开关时，根据旧版子项配置回填广告屏蔽和自定义帖子过滤主开关。

## 验证
- 新增 `ConfigManagerTest` 迁移相关用例，覆盖广告主开关、自定义帖子过滤主开关、普通用户设置迁移和内部缓存跳过场景。
- 定向测试：`./gradlew :app:testDebugUnitTest --tests com.forbidad4tieba.hook.config.ConfigManagerTest --no-daemon`
- 真机覆盖升级验证通过，重新安装后的帖子页主楼下方广告和楼层列表广告均已消失。